### PR TITLE
Refactor `SaveEditor` to accept `installation_path` and `save_folder_name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ too much time to be wasted.
 - It starts by finding the obfuscated autosave file that named with this format: `<Name of the character>.autosave`. For example, see [DEFECT.autosave](example/DEFECT.autosave).
 - The `SaveEditor` object will decrypt the save data and convert it to an editable [JSON object format](example/readable_save_file.json).
 - At this point, you can edit the json object as needed.
-- Finally, call the `SaveEditor.write_json_to_file()` and the script will write the modified save file back to the obfuscated save file format, replacing the old one
+- Finally, call the `SaveEditor.write_json_to_file()` and the script will write the modified save file back to the obfuscated save file format, replacing the old one.
 
 ## How to use the package
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ For example:
     
     save_file = save_editor.get_json()
     save_file['current_health'] = 1000
-    save_file['...'] = 'something-something'
+    save_file['some-key'] = 'something-something'
     
     # don't forget to give it back to the save_editor
     save_editor.set_json(save_file)
@@ -129,4 +129,5 @@ For example:
 
 ## Disclaimer
 
-I got the save file encryption logic from [Kirill89's gist](https://gist.github.com/Kirill89/514edad0ac80af7dfc036871ccf0f877) written in JS. What I did was only rewriting it in python and adding features so that the save data can be programmatically edited.
+I got the save file encryption logic from [Kirill89's gist](https://gist.github.com/Kirill89/514edad0ac80af7dfc036871ccf0f877) written in JS. 
+What I did was only rewriting it in python and adding modularity of the save editor.

--- a/README.md
+++ b/README.md
@@ -24,11 +24,10 @@ from spireslayer.decks import Deck
 from spireslayer.card import Card
 from spireslayer.templates.defect_card import GLACIER, DEFRAGMENT, BLIZZARD
 
-# Declare a valid path to the save folder
-save_file_path = "C:\Program Files (x86)\Steam\steamapps\common\SlayTheSpire\saves"
-
-# Declare a save editor that points to the save_file path
-save_editor = SaveEditor(save_file_path)
+# Declare a save editor that points to the path of your root game installation
+save_editor = SaveEditor(
+    installation_path="C:\\Program Files (x86)\\Steam\\steamapps\\common\\SlayTheSpire",
+)
 
 # Edit whatever you want.
 # here we are making custom powerful deck for our Defect
@@ -55,34 +54,48 @@ save_editor.update_max_health(500)
 save_editor.update_hand_size(10)
 save_editor.update_energy_per_turn(20)
 
+# for attributes that are not yet provided within the package, you can use the generic update_attribute method
+# you can find the key for each attribute in the example JSON save file provided in  this project
+save_editor.update_attribute('current_health', 90)
+save_editor.update_attribute('hand_size', 10)
+
 # After customization is finished, call this method to rewrite the save data back to the original place.
-# The old save file will be replaced.
+# WARNING: The old save file will be replaced.
 save_editor.write_json_to_file()
 ```
 
 ### 2. Running the save file editor
 
-- Open the game. You can create a new game or continue your session. 
+- Open the game. Create a new game or continue any session. 
 - On the first encounter after loading the game, hit the menu and choose `Save & Quit`.
-- From the main menu, switch back to your script and run it. You don't need to close the game.
-- Back to your game and click `Continue`. Enjoy the game!
+- From the main menu, switch back to the script and run it. Closing the game is unnecessary.
+- Switch back to the game and click `Continue`. Enjoy the game!
 
-## Note
+## Notes
+- This package now supports Colorless Card, and nearly all 4 playable hero's cards (thanks [@gabrekt](https://github.com/gabrekt)!).
+- There is a [know issue](https://github.com/rahmatnazali/spireslayer/issues/13) with the Watcher's Rushdown Card not being correctly recognized.
+- For any change that are not yet supported within the package, please use the provided API `SaveEditor.get_json()` and 
+change it directly.
+For example:
 
-Currently, the package only supports The Defect.
-For other character, you can create the method yourself (PR is greatly appreciated!) or alternatively use the provided API `SaveEditor.get_json()` to get the JSON formatted save file,  change the JSON directly, and assign it back with the provided API `SaveEditor.set_json()`. For example:
+    ```python3
+    from spireslayer.save_editor import SaveEditor
+    
+    save_editor = SaveEditor()
+    
+    save_file = save_editor.get_json()
+    save_file['current_health'] = 1000
+    save_file['...'] = 'something-something'
+    
+    # don't forget to give it back to the save_editor
+    save_editor.set_json(save_file)
+    
+    save_editor.write_json_to_file()
+    ```
 
-```python
-from spireslayer.save_editor import SaveEditor
+    Refer to the [readable save file example](example/readable_save_file.json) for more available keys.
 
-editor = SaveEditor(...)
-
-save_file = editor.get_json()
-save_file['current_health'] = 1000
-editor.set_json(save_file)
-```
-
-Refer to the [readable save file example](example/readable_save_file.json) for more example.
+- PR is always appreciated!
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ save_editor = SaveEditor(
 )
 ```
 
-### 2. Creating your own save file editor
+### 2. Create your editor script
 
 Create your own editor behavior by importing the `SaveEditor` to your python script:
 
@@ -93,7 +93,7 @@ save_editor.update_attribute('hand_size', 10)
 save_editor.write_json_to_file()
 ```
 
-### 3. Running the save file editor
+### 3. Run the editor
 
 - Open the game. Create a new game or continue any session. 
 - On the first encounter after loading the game, hit the menu and choose `Save & Quit`.

--- a/README.md
+++ b/README.md
@@ -12,25 +12,54 @@ too much time to be wasted.
 
 ## How to use the package
 
+### 1. Install & Identify
+
 Install the package with `pip install spireslayer`.
 
-### 1. Creating your own save file editor
+Identify your game installation path.
 
-Create your own script as needed, for example:
+This package assumes the Steam default installation on Windows: `C:\\Program Files (x86)\\Steam\\steamapps\\common\\SlayTheSpire`.
+
+If your installation happened to be using the default, then you don't need to pass any arguments when calling the `SaveEditor`. 
+The package will handle it for you:
+
+```python3
+from spireslayer.save_editor import SaveEditor
+
+save_editor = SaveEditor()
+```
+
+For any custom path (e.g. other marketplace or OS), please specify the installation path when initializing the `SaveEditor` class:
+
+```python3
+from spireslayer.save_editor import SaveEditor
+
+# custom Windows path
+save_editor = SaveEditor(
+    installation_path="D:\\MyGames\\SlayTheSpire",
+)
+
+# or linux path
+save_editor = SaveEditor(
+    installation_path="/home/rahmat/.steam/debian-installation/steamapps/common/SlayTheSpire",
+)
+```
+
+### 2. Creating your own save file editor
+
+Create your own editor behavior by importing the `SaveEditor` to your python script:
 
 ```python
+# defect_editor.py
+
 from spireslayer.save_editor import SaveEditor
 from spireslayer.decks import Deck
 from spireslayer.card import Card
 from spireslayer.templates.defect_card import GLACIER, DEFRAGMENT, BLIZZARD
 
-# Declare a save editor that points to the path of your root game installation
-save_editor = SaveEditor(
-    installation_path="C:\\Program Files (x86)\\Steam\\steamapps\\common\\SlayTheSpire",
-)
+save_editor = SaveEditor()
 
-# Edit whatever you want.
-# here we are making custom powerful deck for our Defect
+# let's start by creating a custom powerful deck for our Defect
 save_editor.set_deck(Deck([
     Card(GLACIER),
     Card(GLACIER),
@@ -48,14 +77,14 @@ save_editor.set_deck(Deck([
 # or maybe increase our Defect's max orb
 save_editor.update_max_orbs(15)
 
-# or anything that can be adjusted to your need
+# or basically anything you need
 save_editor.update_current_health(400)
 save_editor.update_max_health(500)
 save_editor.update_hand_size(10)
 save_editor.update_energy_per_turn(20)
 
-# for attributes that are not yet provided within the package, you can use the generic update_attribute method
-# you can find the key for each attribute in the example JSON save file provided in  this project
+# for attributes that are not yet provided within the package's method, you can use the generic update_attribute method
+# you can find the key for each attribute in the example JSON save file provided in this project
 save_editor.update_attribute('current_health', 90)
 save_editor.update_attribute('hand_size', 10)
 
@@ -64,12 +93,13 @@ save_editor.update_attribute('hand_size', 10)
 save_editor.write_json_to_file()
 ```
 
-### 2. Running the save file editor
+### 3. Running the save file editor
 
 - Open the game. Create a new game or continue any session. 
 - On the first encounter after loading the game, hit the menu and choose `Save & Quit`.
-- From the main menu, switch back to the script and run it. Closing the game is unnecessary.
-- Switch back to the game and click `Continue`. Enjoy the game!
+- From the main menu, switch to the script and run it. Closing the game is actually unnecessary.
+- Switch back to the game and click `Continue`. 
+- Enjoy the game!
 
 ## Notes
 - This package now supports Colorless Card, and nearly all 4 playable hero's cards (thanks [@gabrekt](https://github.com/gabrekt)!).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spireslayer"
-version = "1.0.0"
+version = "1.1.0"
 keywords = ["slay-the-spire", "slay", "spire", "save", "editor"]
 authors = [
   { name="Rahmat Nazali Salimi", email="rahmatnazali95@gmail.com" },

--- a/src/example.py
+++ b/src/example.py
@@ -3,7 +3,7 @@ from spireslayer.save_editor import SaveEditor
 
 
 if __name__ == '__main__':
-    save_file_path = "/path/to/save/folder"
+    save_file_path = "C:\\Program Files (x86)\\Steam\\steamapps\\common\\SlayTheSpire\\saves"
     save_editor = SaveEditor(save_file_path=save_file_path)
 
     # In here, you can do whatever you want on your save file

--- a/src/example.py
+++ b/src/example.py
@@ -3,8 +3,9 @@ from spireslayer.save_editor import SaveEditor
 
 
 if __name__ == '__main__':
-    save_file_path = "C:\\Program Files (x86)\\Steam\\steamapps\\common\\SlayTheSpire\\saves"
-    save_editor = SaveEditor(save_file_path=save_file_path)
+    save_editor = SaveEditor(
+        installation_path="C:\\Program Files (x86)\\Steam\\steamapps\\common\\SlayTheSpire",
+    )
 
     # In here, you can do whatever you want on your save file
     save_editor.update_current_health()

--- a/src/spireslayer/card.py
+++ b/src/spireslayer/card.py
@@ -1,5 +1,3 @@
-
-
 class Card(object):
     def __init__(self, id: str, misc: int = 0, upgrades: int = 1) -> None:
         super().__init__()

--- a/src/spireslayer/save_editor.py
+++ b/src/spireslayer/save_editor.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import os
+from typing import Optional
 
 from .card import Card
 from .decks import Deck
@@ -8,11 +9,17 @@ from .decks import Deck
 
 class SaveEditor(object):
     def __init__(self,
-                 save_file_path: str = "C:\\Program Files (x86)\\Steam\\steamapps\\common\\SlayTheSpire\\saves",
+                 installation_path: str = "C:\\Program Files (x86)\\Steam\\steamapps\\common\\SlayTheSpire",
+                 save_folder_name: Optional[str] = "saves",
                  key: str = "key"
                  ) -> None:
         super().__init__()
-        self.root_path = save_file_path
+
+        if save_folder_name is not None:
+            self.path = f"{installation_path}\\{save_folder_name}"
+        else:
+            self.path = installation_path
+
         self.key = key
         self.save_file_path = self.find_autosave_file()
         self.encoded_save_data: str = self.load_encoded_save_data_from_file()
@@ -25,12 +32,12 @@ class SaveEditor(object):
         return self.json_save_data
 
     def find_autosave_file(self):
-        assert self.root_path is not None, "Root path is None"
-        possible_save_files = os.listdir(self.root_path)
+        assert os.path.isdir(self.path), f"Path {self.path} doesn't exist"
+        possible_save_files = os.listdir(self.path)
         for filename in possible_save_files:
             if filename.endswith('.autosave'):
-                return os.path.join(self.root_path, filename)
-        raise ValueError(f"No .autosave file found on {self.root_path}")
+                return os.path.join(self.path, filename)
+        raise ValueError(f"No .autosave file found on {self.path}")
 
     def load_encoded_save_data_from_file(self):
         with open(self.save_file_path, 'r') as save_file:

--- a/src/spireslayer/save_editor.py
+++ b/src/spireslayer/save_editor.py
@@ -16,7 +16,7 @@ class SaveEditor(object):
         super().__init__()
 
         if save_folder_name is not None:
-            self.path = f"{installation_path}\\{save_folder_name}"
+            self.path = os.path.join(installation_path, save_folder_name)
         else:
             self.path = installation_path
 

--- a/src/spireslayer/save_editor.py
+++ b/src/spireslayer/save_editor.py
@@ -1,7 +1,7 @@
 import base64
 import json
 import os
-from typing import Optional
+from typing import Optional, Union
 
 from .card import Card
 from .decks import Deck
@@ -78,24 +78,26 @@ class SaveEditor(object):
         final_data = base64.b64encode(bytes(decoded_char_list))
         return final_data
 
+    def update_attribute(self, attribute_name: str, value: Union[int, str]) -> None:
+        self.json_save_data[attribute_name] = value
+
     def update_current_health(self, health: int = 72):
-        self.json_save_data['current_health'] = health
+        self.update_attribute('current_health', health)
 
     def update_max_health(self, health: int = 72):
-        self.json_save_data['max_health'] = health
+        self.update_attribute('max_health', health)
 
-    def update_max_orbs(self, max_orbs: int = 0):
-        self.json_save_data['max_orbs'] = max_orbs
+    def update_max_orbs(self, max_orbs: int = 3):
+        self.update_attribute('max_orbs', max_orbs)
 
     def update_hand_size(self, hand_size: int = 5):
-        self.json_save_data['hand_size'] = hand_size
+        self.update_attribute('hand_size', hand_size)
 
-    def update_energy_per_turn(self, red: int = 3):
-        self.json_save_data['red'] = red
-        assert self.get_json().get('red') == red
+    def update_energy_per_turn(self, energy: int = 3):
+        self.update_attribute('red', energy)
 
     def set_deck(self, deck: Deck):
-        self.json_save_data["cards"] = deck.to_json()
+        self.update_attribute('cards', deck.to_json())
 
     def add_card(self, card: Card):
-        self.json_save_data["cards"].append(card.to_json())
+        self.json_save_data['cards'].append(card.to_json())

--- a/src/spireslayer/save_editor.py
+++ b/src/spireslayer/save_editor.py
@@ -9,7 +9,7 @@ from .decks import Deck
 
 class SaveEditor(object):
     def __init__(self,
-                 installation_path: str = "C:\\Program Files (x86)\\Steam\\steamapps\\common\\SlayTheSpire",
+                 installation_path: Optional[str] = "C:\\Program Files (x86)\\Steam\\steamapps\\common\\SlayTheSpire",
                  save_folder_name: Optional[str] = "saves",
                  key: str = "key"
                  ) -> None:

--- a/src/spireslayer/save_editor.py
+++ b/src/spireslayer/save_editor.py
@@ -8,7 +8,7 @@ from .decks import Deck
 
 class SaveEditor(object):
     def __init__(self,
-                 save_file_path: str = "/path/to/save/folder",
+                 save_file_path: str = "C:\\Program Files (x86)\\Steam\\steamapps\\common\\SlayTheSpire\\saves",
                  key: str = "key"
                  ) -> None:
         super().__init__()

--- a/src/spireslayer/templates/colorless_card.py
+++ b/src/spireslayer/templates/colorless_card.py
@@ -1,5 +1,5 @@
+# Colorless Cards
 
-# colorless_cards.py
 
 # Uncommon Cards
 BANDAGE_UP = "Bandage Up"

--- a/src/spireslayer/templates/defect_card.py
+++ b/src/spireslayer/templates/defect_card.py
@@ -1,3 +1,6 @@
+# Card for The Defect (Blue)
+
+
 STRIKE = "Strike_B"
 DEFEND = "Defend_B"
 

--- a/src/spireslayer/templates/defect_deck.py
+++ b/src/spireslayer/templates/defect_deck.py
@@ -2,7 +2,6 @@ from spireslayer.card import Card
 from spireslayer.decks import Deck
 from spireslayer.templates.defect_card import LEAP, ZAP, DEFRAGMENT, THUNDER_STRIKE, GLACIER, BLIZZARD
 
-
 lightning_deck = Deck([
     Card(LEAP),
     Card(LEAP),
@@ -17,7 +16,6 @@ lightning_deck = Deck([
     Card(DEFRAGMENT),
     Card(THUNDER_STRIKE),
 ])
-
 
 frost_deck = Deck([
     Card(GLACIER),

--- a/src/spireslayer/templates/ironclad_card.py
+++ b/src/spireslayer/templates/ironclad_card.py
@@ -1,5 +1,5 @@
-# ironclad_card.py
-# Also red cards.
+# Card for Ironclad (Red)
+
 
 # Starter Cards
 BASH = "Bash"

--- a/src/spireslayer/templates/ironclad_deck.py
+++ b/src/spireslayer/templates/ironclad_deck.py
@@ -1,11 +1,8 @@
 from spireslayer.card import Card
 from spireslayer.decks import Deck
 from spireslayer.templates.ironclad_card import *
-from spireslayer.templates.colorless_card import INSIGHT, FLASH_OF_STEEL
 
-#Strenght focus deck
-
-strenght_focus = Deck([
+strength_focus_deck = Deck([
     Card(FLEX),
     Card(FLEX),
     Card(INFLAME),
@@ -20,7 +17,7 @@ strenght_focus = Deck([
     Card(HEAVY_BLADE)
 ])
 
-bodyslam = Deck([
+body_slam_deck = Deck([
     Card(BARRICADE),
     Card(ENTRENCH),
     Card(BODY_SLAM),

--- a/src/spireslayer/templates/silent_card.py
+++ b/src/spireslayer/templates/silent_card.py
@@ -1,6 +1,4 @@
-#Silent_card.py
-
-#Green cards
+# Card for Silent (Green)
 
 
 # Starter Cards

--- a/src/spireslayer/templates/silent_deck.py
+++ b/src/spireslayer/templates/silent_deck.py
@@ -2,10 +2,7 @@ from spireslayer.card import Card
 from spireslayer.decks import Deck
 from spireslayer.templates.silent_card import *
 
-
-#Poison deck
-
-poison = Deck([
+poison_deck = Deck([
     Card(BOUNCING_FLASK),
     Card(BOUNCING_FLASK),
     Card(BOUNCING_FLASK),
@@ -23,10 +20,7 @@ poison = Deck([
     Card(CALTROPS)
 ])
 
-#Shiv
-
-
-shiv_and_draw = Deck([
+shiv_and_draw_deck = Deck([
     Card(ACCURACY),
     Card(ACCURACY),
     Card(ACCURACY),

--- a/src/spireslayer/templates/watcher_card.py
+++ b/src/spireslayer/templates/watcher_card.py
@@ -1,4 +1,5 @@
-# watcher_cards.py
+# Card for The Watcher (Purple)
+
 
 # Starter Cards
 DEFEND_W = "Defend"
@@ -47,7 +48,7 @@ NIRVANA = "Nirvana"
 PERSEVERANCE = "Perseverance"
 PRAY = "Pray"
 REACH_HEAVEN = "Reach Heaven"
-RUSHDOWN = "Rushdown"
+RUSHDOWN = "Rushdown"  # Known issue: https://github.com/rahmatnazali/spireslayer/issues/13
 SANCTITY = "Sanctity"
 SANDS_OF_TIME = "Sands of Time"
 SIGNATURE_MOVE = "Signature Move"

--- a/src/spireslayer/templates/watcher_deck.py
+++ b/src/spireslayer/templates/watcher_deck.py
@@ -1,9 +1,7 @@
 from spireslayer.card import Card
 from spireslayer.decks import Deck
 from spireslayer.templates.watcher_card import *
-from spireslayer.templates.colorless_card import INSIGHT, MADNESS, FLASH_OF_STEEL
-
-#Infinite decks
+from spireslayer.templates.colorless_card import INSIGHT, FLASH_OF_STEEL
 
 calm_and_neutral = Deck([
     Card(INNER_PEACE),
@@ -23,7 +21,7 @@ calm_and_wrath = Deck([
 divinity_and_wrath = Deck([
     Card(PRAY),
     Card(PROSTRATE),
-    Card(RUSHDOWN), #This card is mistaken for madness. Check data.
+    Card(RUSHDOWN),
     Card(ERUPTION),
     Card(INSIGHT)
 ])

--- a/src/tests/test_save_editor.py
+++ b/src/tests/test_save_editor.py
@@ -4,14 +4,14 @@ from spireslayer.save_editor import SaveEditor
 
 
 def test_initialization():
-    save_editor = SaveEditor(save_file_path="tests")
+    save_editor = SaveEditor(installation_path="tests", save_folder_name=None)
     original_save_file = save_editor.get_json()
     assert len(original_save_file) == 112
     assert save_editor.key == "key"
 
 
 def test_set_json():
-    save_editor = SaveEditor(save_file_path="tests")
+    save_editor = SaveEditor(installation_path="tests", save_folder_name=None)
     original_save_file = save_editor.get_json()
     new_save_file = {}
     save_editor.set_json(new_save_file)
@@ -21,7 +21,7 @@ def test_set_json():
 
 
 def test_update_current_health():
-    save_editor = SaveEditor(save_file_path="tests")
+    save_editor = SaveEditor(installation_path="tests", save_folder_name=None)
     original_health = save_editor.get_json()['current_health']
     assert original_health == 500
     save_editor.update_current_health(100)
@@ -31,7 +31,7 @@ def test_update_current_health():
 
 
 def test_update_max_health():
-    save_editor = SaveEditor(save_file_path="tests")
+    save_editor = SaveEditor(installation_path="tests", save_folder_name=None)
     original_max_health = save_editor.get_json()['max_health']
     assert original_max_health == 500
     save_editor.update_max_health(100)
@@ -41,7 +41,7 @@ def test_update_max_health():
 
 
 def test_update_max_orbs():
-    save_editor = SaveEditor(save_file_path="tests")
+    save_editor = SaveEditor(installation_path="tests", save_folder_name=None)
     original_max_orbs = save_editor.get_json()['max_orbs']
     assert original_max_orbs == 10
     save_editor.update_max_orbs(15)
@@ -51,7 +51,7 @@ def test_update_max_orbs():
 
 
 def test_update_hand_size():
-    save_editor = SaveEditor(save_file_path="tests")
+    save_editor = SaveEditor(installation_path="tests", save_folder_name=None)
     original_hand_size = save_editor.get_json()['hand_size']
     assert original_hand_size == 10
     save_editor.update_hand_size(15)
@@ -61,7 +61,7 @@ def test_update_hand_size():
 
 
 def test_update_energy_per_turn():
-    save_editor = SaveEditor(save_file_path="tests")
+    save_editor = SaveEditor(installation_path="tests", save_folder_name=None)
     original_energy_per_turn = save_editor.get_json()['red']
     assert original_energy_per_turn == 20
     save_editor.update_energy_per_turn(30)
@@ -71,7 +71,7 @@ def test_update_energy_per_turn():
 
 
 def test_set_deck():
-    save_editor = SaveEditor(save_file_path="tests")
+    save_editor = SaveEditor(installation_path="tests", save_folder_name=None)
     deck = Deck([
         Card("1"),
         Card("2"),
@@ -83,7 +83,7 @@ def test_set_deck():
 
 
 def test_add_card():
-    save_editor = SaveEditor(save_file_path="tests")
+    save_editor = SaveEditor(installation_path="tests", save_folder_name=None)
     deck = Deck([
         Card("1"),
         Card("2"),


### PR DESCRIPTION
Known facts:
1. Default installation path for windows is `C:\\Program Files (x86)\\Steam\\steamapps\\common\\SlayTheSpire`
2. The folder in which the save files are contained is named `saves`

and then considering these possibilities:
1. Game installation path may be customized on user's behalf, so the default installation path wont always work. We also have player with different OS that doesn't necessarily has the same path pattern.
2. Future version of the game _might_ change/rename the `saves` folder inside the game installation. Probably would never happen, but if it does then this package will simply break

In this PR, I would like to separate the full path of the save folder to `installation_path` and `save_folder_name`. Both with the currently working value as the default value, but entirely customizable as needed.


### Example 1: Windows user with default installation
```python3
from spireslayer.save_editor import SaveEditor

# this should work out of the box without any configuration needed
save_editor = SaveEditor()
```

### Example 2: Windows user (or Linux user, for example) with custom installation path
```python3
from spireslayer.save_editor import SaveEditor

# installation_path can be configured as needed
save_editor = SaveEditor(
    installation_path="D:\\MyGames\\SlayTheSpire",
)

# or
save_editor = SaveEditor(
    installation_path="/home/rahmat/.steam/debian-installation/steamapps/common/SlayTheSpire",
)
```

### Example 3: Custom save folder name
```python3
from spireslayer.save_editor import SaveEditor

# case that probably will never happen (e.g. due to version change)
# but if it happened then only small change from the user is needed instead of bumping the package version
save_editor = SaveEditor(
    save_folder_name="savestates",
)
```

Other than that, small changes are also included in several files to adhere with PEP styling.